### PR TITLE
Bump to 0.12.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,3 @@ jobs:
       before_install:
         - docker pull quay.io/hairmare/centos_rpmdev
       script: docker run --rm -ti -v `pwd`:'/git' quay.io/hairmare/centos8_rpmdev /git/.travis/rpm.sh
-    - stage: main
-      name: "Fedora RPM"
-      before_install:
-        - docker pull quay.io/hairmare/fedora_rpmdev
-      script: docker run --rm -ti -v `pwd`:'/git' quay.io/hairmare/fedora_rpmdev /git/.travis/rpm.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: minimal
+
+services:
+  - docker
+
+jobs:
+  include:
+    - stage: main
+      name: "RPMlint"
+      before_install:
+        - docker pull quay.io/hairmare/fedora_rpmdev
+      script: docker run --rm -ti -v `pwd`:'/git' quay.io/hairmare/fedora_rpmdev rpmlint ocaml-base.spec
+    - stage: main
+      name: "CentOS RPM"
+      before_install:
+        - docker pull quay.io/hairmare/centos_rpmdev
+      script: docker run --rm -ti -v `pwd`:'/git' quay.io/hairmare/centos_rpmdev /git/.travis/rpm.sh
+    - stage: main
+      name: "Fedora RPM"
+      before_install:
+        - docker pull quay.io/hairmare/fedora_rpmdev
+      script: docker run --rm -ti -v `pwd`:'/git' quay.io/hairmare/fedora_rpmdev /git/.travis/rpm.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
       name: "CentOS RPM"
       before_install:
         - docker pull quay.io/hairmare/centos_rpmdev
-      script: docker run --rm -ti -v `pwd`:'/git' quay.io/hairmare/centos_rpmdev /git/.travis/rpm.sh
+      script: docker run --rm -ti -v `pwd`:'/git' quay.io/hairmare/centos8_rpmdev /git/.travis/rpm.sh
     - stage: main
       name: "Fedora RPM"
       before_install:

--- a/.travis/rpm.sh
+++ b/.travis/rpm.sh
@@ -8,9 +8,15 @@ OBS_OS=`source /etc/os-release; echo $ID`
 
 case $OBS_OS in
 "centos")
-    OBS_DIST="CentOS_7"
+    OBS_VER=`source /etc/os-release; echo $VERSION_ID`
+    OBS_DIST="CentOS_${OBS_VER}"
     yum -y install \
         epel-release
+    case $OBS_VER in
+    "8")
+        yum-config-manager --set-enabled  PowerTools
+        ;;
+    esac
     ;;
 "fedora")
     V=`source /etc/os-release; echo $VERSION_ID`

--- a/.travis/rpm.sh
+++ b/.travis/rpm.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# RPM build wrapper for ocaml-base, runs inside the build container on travis-ci
+
+set -xe
+
+OBS_OS=`source /etc/os-release; echo $ID`
+
+case $OBS_OS in
+"centos")
+    OBS_DIST="CentOS_7"
+    yum -y install \
+        epel-release
+    ;;
+"fedora")
+    V=`source /etc/os-release; echo $VERSION_ID`
+    OBS_DIST="Fedora_${V}"
+    ;;
+esac
+
+curl -o /etc/yum.repos.d/liquidsoap.repo "https://download.opensuse.org/repositories/home:/radiorabe:/liquidsoap/${OBS_DIST}/home:radiorabe:liquidsoap.repo"
+
+chown root:root ocaml-base.spec
+
+build-rpm-package.sh ocaml-base.spec

--- a/ocaml-base.spec
+++ b/ocaml-base.spec
@@ -12,7 +12,7 @@ Source0:        https://github.com/janestreet/base/archive/v%{version}/%{name}-%
 BuildRequires:  ocaml
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-sexplib0-devel
-BuildRequires:  ocaml-dune
+BuildRequires:  ocaml-dune-devel
 
 %description
 A Part of Jane Street's Core library The Core suite of libraries is

--- a/ocaml-base.spec
+++ b/ocaml-base.spec
@@ -1,19 +1,18 @@
 Name:           ocaml-base
-Version:       	0.11.1
-Release:        0.2%{?dist}
+Version:        0.12.2
+Release:        0.0%{?dist}
 Summary:        Standard library for OCaml
 
 %global libname %(echo %{name} | sed -e 's/^ocaml-//')
 
-# NOTE: The license changes to MIT at some point after the 0.11.1 tag
-License:        Apache-2.0
+License:        MIT
 URL:            https://github.com/janestreet/base/
 Source0:        https://github.com/janestreet/base/archive/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:  ocaml
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-sexplib0-devel
-BuildRequires:	ocaml-dune
+BuildRequires:  ocaml-dune
 
 %description
 A Part of Jane Street's Core library The Core suite of libraries is
@@ -32,10 +31,6 @@ files for developing applications that use %{name}.
 %prep
 %autosetup -n %{libname}-%{version}
 
-# Generate debuginfo, or try to.
-sed 's/ocamlc/ocamlc -g/g' -i Makefile
-sed 's/ocamlopt/ocamlopt -g/g' -i Makefile
-
 %build
 %make_build
 
@@ -48,7 +43,7 @@ dune install --prefix=$OCAMLFIND_DESTDIR --libdir=$OCAMLFIND_DESTDIR
 %files
 %doc README.org
 %doc %{_libdir}/ocaml/doc/%{libname}
-%license LICENSE.txt
+%license LICENSE.md
 %{_libdir}/ocaml/%{libname}
 %{_libdir}/ocaml/stublibs/dll%{libname}_stubs.so
 %ifarch %{ocaml_native_compiler}
@@ -60,7 +55,7 @@ dune install --prefix=$OCAMLFIND_DESTDIR --libdir=$OCAMLFIND_DESTDIR
 %endif
 
 %files devel
-%license LICENSE.txt
+%license LICENSE.md
 %ifarch %{ocaml_native_compiler}
 %{_libdir}/ocaml/%{libname}/*.a
 %{_libdir}/ocaml/%{libname}/*.cmxa
@@ -69,6 +64,10 @@ dune install --prefix=$OCAMLFIND_DESTDIR --libdir=$OCAMLFIND_DESTDIR
 %endif
 
 %changelog
+* Fri Dec 13 2019 Lucas Bickel <hairmare@rabe.ch> - 0.12.2-0.0
+- Bump to 0.12.2
+- Switch to MIT license
+
 * Sun Dec  8 2019 Lucas Bickel <hairmare@rabe.ch> - 0.11.1-0.2
 - Fix libdir env variable
 - Use ocaml-dune instead of jbuilder


### PR DESCRIPTION
This is the first version that also needs CentOS 8 to build properly. I'll look into backporting what is needed at a later stage (if at all).